### PR TITLE
fix(er-1776): preserve crcwatch request params

### DIFF
--- a/pkg/crcwatch/crcwatch_test.go
+++ b/pkg/crcwatch/crcwatch_test.go
@@ -2,10 +2,13 @@ package crcwatch
 
 import (
 	"errors"
+	"net/url"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
@@ -51,6 +54,23 @@ func (f *fakeWatchClient) getStartCall() int {
 func (f *fakeWatchClient) Channel() <-chan *models.ResourceChangeEvent  { return f.eventCh }
 func (f *fakeWatchClient) ErrorChannel() <-chan *watchor.ErrorEvent     { return f.errCh }
 func (f *fakeWatchClient) WarningChannel() <-chan *watchor.WarningEvent { return f.warnCh }
+
+type fakeClientRequest struct {
+	runtime.TestClientRequest
+	query url.Values
+}
+
+func (f *fakeClientRequest) SetQueryParam(name string, values ...string) error {
+	if f.query == nil {
+		f.query = make(url.Values)
+	}
+	f.query[name] = values
+	return nil
+}
+
+func (f *fakeClientRequest) GetQueryParams() url.Values {
+	return f.query
+}
 
 var _ = Describe("Watch", func() {
 	var (
@@ -123,5 +143,20 @@ var _ = Describe("NewWatch", func() {
 		w, err := NewWatch([]string{"TestResource"}, SetUserInfo(&client.UserInfo{}))
 		Expect(w).To(BeNil())
 		Expect(err).ToNot(BeNil())
+	})
+})
+
+var _ = Describe("Bypass whitelist header", func() {
+	It("should preserve origin request writer", func() {
+		origin := runtime.ClientRequestWriterFunc(func(req runtime.ClientRequest, _ strfmt.Registry) error {
+			return req.SetQueryParam("limit", "500")
+		})
+
+		req := &fakeClientRequest{}
+		err := NewBypassWhiteListHeader(origin).WriteToRequest(req, nil)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(req.GetQueryParams().Get("limit")).To(Equal("500"))
+		Expect(req.GetHeaderParams().Get("x-bypass-whitelist")).To(Equal("true"))
 	})
 })

--- a/pkg/crcwatch/help.go
+++ b/pkg/crcwatch/help.go
@@ -6,17 +6,28 @@ import (
 )
 
 type ExtraHeaderStruct struct {
-	Key   string
-	Value string
+	key    string
+	value  string
+	origin runtime.ClientRequestWriter
 }
 
-func (e *ExtraHeaderStruct) WriteToRequest(req runtime.ClientRequest, _ strfmt.Registry) error {
-	return req.SetHeaderParam(e.Key, e.Value)
-}
-
-func NewBypassWhiteListHeader() *ExtraHeaderStruct {
+func NewExtraHeaderStruct(key, value string, origin runtime.ClientRequestWriter) *ExtraHeaderStruct {
 	return &ExtraHeaderStruct{
-		Key:   "x-bypass-whitelist",
-		Value: "true",
+		key:    key,
+		value:  value,
+		origin: origin,
 	}
+}
+
+func (e *ExtraHeaderStruct) WriteToRequest(req runtime.ClientRequest, fmt strfmt.Registry) error {
+	if e.origin != nil {
+		if err := e.origin.WriteToRequest(req, fmt); err != nil {
+			return err
+		}
+	}
+	return req.SetHeaderParam(e.key, e.value)
+}
+
+func NewBypassWhiteListHeader(origin runtime.ClientRequestWriter) *ExtraHeaderStruct {
+	return NewExtraHeaderStruct("x-bypass-whitelist", "true", origin)
 }

--- a/pkg/crcwatch/resource_change_watch_client.go
+++ b/pkg/crcwatch/resource_change_watch_client.go
@@ -101,8 +101,11 @@ func NewWatchOriClient(resourceTypes []string, opts *Options) (*watchor.Resource
 	}
 
 	var options resource_change_client.ClientOption = func(op *runtime.ClientOperation) {
-		op.AuthInfo = httptransport.BasicAuth(opts.APIUsername, opts.APIPassword)
-		op.Params = NewBypassWhiteListHeader()
+		op.AuthInfo = httptransport.Compose(
+			op.AuthInfo,
+			httptransport.BasicAuth(opts.APIUsername, opts.APIPassword),
+		)
+		op.Params = NewBypassWhiteListHeader(op.Params)
 	}
 
 	crcWatchClient, err := watchor.NewResourceChangeWatchClient(&watchor.NewResourceChangeWatchClientParams{


### PR DESCRIPTION
## 问题原因

PR #9 为 crcwatch 请求添加 bypass whitelist header 时，直接把 `op.Params` 替换成了只写 header 的 request writer。

但 go-openapi 生成的 `op.Params` 原本负责写入请求参数，例如 `limit`、`resource_type`、`start_revision`。覆盖 `op.Params` 后，这些 query 参数不会再写入 request。

缺少 query 参数后，发往 CloudTower 的请求会退化成 `/v2/api/resource-changes`，crcwatch 会持续拉取默认结果页，导致旧的 resource change event 被重复处理。

## 改动说明

- 将 bypass whitelist header writer 改成包装原始 `op.Params`，先保留原有 query 参数写入，再追加 `x-bypass-whitelist: true` header。
- 保留 BasicAuth，并通过 `httptransport.Compose` 与已有 `AuthInfo` 组合，避免覆盖其他认证逻辑。
- 增加单测覆盖：写入 bypass whitelist header 时，原始 request writer 写入的 query 参数不会丢失。

## 测试记录

- http://jira.smartx.com/browse/ER-1776