### PR TITLE
feat: support insecure crcwatch client

### DIFF
--- a/pkg/crcwatch/crcwatch_test.go
+++ b/pkg/crcwatch/crcwatch_test.go
@@ -2,6 +2,8 @@ package crcwatch
 
 import (
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"sync"
 	"testing"
@@ -109,6 +111,9 @@ var _ = Describe("Watch", func() {
 
 		SetScheme("https")(opts)
 		Expect(opts.Scheme).To(Equal("https"))
+
+		SetAllowInsecure(true)(opts)
+		Expect(opts.AllowInsecure).To(BeTrue())
 	})
 
 	It("should call handler when event received", func() {
@@ -147,6 +152,49 @@ var _ = Describe("NewWatch", func() {
 		Expect(w).To(BeNil())
 		Expect(err).ToNot(BeNil())
 	})
+
+	It("should create crc client with insecure https enabled", func() {
+		server := newLoginTLSServer()
+		defer server.Close()
+
+		u, err := url.Parse(server.URL)
+		Expect(err).ToNot(HaveOccurred())
+
+		watchClient, err := NewWatchOriClient([]string{"vm"}, &Options{
+			UserInfo: &client.UserInfo{
+				Username: "user",
+				Password: "pass",
+				Source:   string(models.UserSourceLOCAL),
+			},
+			Host:          u.Host,
+			Scheme:        u.Scheme,
+			AllowInsecure: true,
+		})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(watchClient).ToNot(BeNil())
+	})
+
+	It("should fail to create crc client for untrusted https when insecure is disabled", func() {
+		server := newLoginTLSServer()
+		defer server.Close()
+
+		u, err := url.Parse(server.URL)
+		Expect(err).ToNot(HaveOccurred())
+
+		watchClient, err := NewWatchOriClient([]string{"vm"}, &Options{
+			UserInfo: &client.UserInfo{
+				Username: "user",
+				Password: "pass",
+				Source:   string(models.UserSourceLOCAL),
+			},
+			Host:   u.Host,
+			Scheme: u.Scheme,
+		})
+
+		Expect(err).To(HaveOccurred())
+		Expect(watchClient).To(BeNil())
+	})
 })
 
 var _ = Describe("Bypass whitelist header", func() {
@@ -163,3 +211,14 @@ var _ = Describe("Bypass whitelist header", func() {
 		Expect(req.GetHeaderParams().Get("x-bypass-whitelist")).To(Equal("true"))
 	})
 })
+
+func newLoginTLSServer() *httptest.Server {
+	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/api/login" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"token":"token"}}`))
+	}))
+}

--- a/pkg/crcwatch/resource_change_watch_client.go
+++ b/pkg/crcwatch/resource_change_watch_client.go
@@ -2,12 +2,15 @@ package crcwatch
 
 import (
 	"errors"
+	"net/http"
 	"time"
 
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
 	apiclient "github.com/smartxworks/cloudtower-go-sdk/v2/client"
 	resource_change_client "github.com/smartxworks/cloudtower-go-sdk/v2/client/resource_change"
+	userclient "github.com/smartxworks/cloudtower-go-sdk/v2/client/user"
 	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
 	watchor "github.com/smartxworks/cloudtower-go-sdk/v2/watchor"
 	"k8s.io/klog"
@@ -51,6 +54,12 @@ func SetScheme(scheme string) OptionFunc {
 	}
 }
 
+func SetAllowInsecure(allow bool) OptionFunc {
+	return func(o *Options) {
+		o.AllowInsecure = allow
+	}
+}
+
 func SetLimit(l int32) OptionFunc {
 	return func(o *Options) {
 		o.Limit = l
@@ -73,6 +82,7 @@ type Options struct {
 	UserInfo               *client.UserInfo
 	Host                   string
 	Scheme                 string
+	AllowInsecure          bool
 	APIUsername            string
 	APIPassword            string
 	PollingInterval        time.Duration
@@ -97,7 +107,7 @@ func NewWatchOriClient(resourceTypes []string, opts *Options) (*watchor.Resource
 		scheme = "http"
 	}
 
-	towerclient, err := apiclient.NewWithUserConfig(apiclient.ClientConfig{
+	towerclient, err := newTowerClient(apiclient.ClientConfig{
 		Host:     opts.Host,
 		BasePath: "v2/api",
 		Schemes:  []string{scheme},
@@ -105,7 +115,7 @@ func NewWatchOriClient(resourceTypes []string, opts *Options) (*watchor.Resource
 		Name:     opts.UserInfo.Username,
 		Password: opts.UserInfo.Password,
 		Source:   models.UserSource(opts.UserInfo.Source),
-	})
+	}, opts.AllowInsecure)
 
 	if err != nil {
 		klog.Errorf("Failed to init api client, err: %s", err)
@@ -135,4 +145,37 @@ func NewWatchOriClient(resourceTypes []string, opts *Options) (*watchor.Resource
 		return nil, err
 	}
 	return crcWatchClient, nil
+}
+
+func newTowerClient(clientConfig apiclient.ClientConfig, userConfig apiclient.UserConfig, insecure bool) (*apiclient.Cloudtower, error) {
+	tlsConfig, err := httptransport.TLSClientAuth(httptransport.TLSClientOptions{
+		InsecureSkipVerify: insecure, // #nosec G402
+	})
+	if err != nil {
+		return nil, err
+	}
+	httpTransport := http.DefaultTransport.(*http.Transport).Clone()
+	httpTransport.TLSClientConfig = tlsConfig
+	httpClient := &http.Client{Transport: httpTransport}
+
+	transport := httptransport.NewWithClient(clientConfig.Host, clientConfig.BasePath, clientConfig.Schemes, httpClient)
+	client := apiclient.New(transport, strfmt.Default)
+
+	params := userclient.NewLoginParams()
+	params.RequestBody = &models.LoginInput{
+		Username: &userConfig.Name,
+		Password: &userConfig.Password,
+		Source:   userConfig.Source.Pointer(),
+	}
+
+	resp, err := client.User.Login(params)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Payload == nil || resp.Payload.Data == nil || resp.Payload.Data.Token == nil {
+		return nil, errors.New("login response missing token")
+	}
+
+	transport.DefaultAuthentication = httptransport.APIKeyAuth("Authorization", "header", *resp.Payload.Data.Token)
+	return client, nil
 }


### PR DESCRIPTION
## Summary
- add crcwatch AllowInsecure option with SetAllowInsecure
- create the CloudTower SDK client with an insecure TLS HTTP client when enabled
- cover trusted/untrusted HTTPS behavior with crcwatch tests

## Tests
- go test ./pkg/crcwatch -count=1
- go test ./pkg/...

Note: go test ./... currently fails in tools/codegen due golang.org/x/tools@v0.12.0 tokeninternal compile error under this Go toolchain, unrelated to this change.